### PR TITLE
[-] MO : fixed Notice message when save config

### DIFF
--- a/socolissimo.php
+++ b/socolissimo.php
@@ -29,7 +29,7 @@ if (!defined('_PS_VERSION_'))
 
 class Socolissimo extends CarrierModule
 {
-	private $html = '';
+	private $_html = '';
 	private $post_errors = array();
 	private $api_num_version = '4.0';
 	private $config = array(


### PR DESCRIPTION
ON PS 1.6.0.9 there is a notice when trying to save the configuration :
Notice à la ligne 281 du fichier /var/www/html/projets/stmichel/www/modules/socolissimo/socolissimo.php
[8] Undefined property: Socolissimo::$_html
